### PR TITLE
Update wasmer.toml

### DIFF
--- a/wasmer.toml
+++ b/wasmer.toml
@@ -5,6 +5,7 @@ description = 'The JavaScript runtime that brings JavaScript to Wasmer Edge.'
 license = 'MIT'
 readme = 'README.md'
 repository = 'https://github.com/wasmerio/winterjs/'
+entrypoint = 'winterjs'
 
 # See more keys and definitions at https://docs.wasmer.io/registry/manifest
 


### PR DESCRIPTION
Add entrypoint to not break wasmer usage.

Current error:
```
$ wasmer run wasmer/winterjs  --net --mapdir=output:.output  output/server/index.mjs
error: Unable to determine the WEBC file's entrypoint. Please choose one of ["wasmer-winter", "winterjs"]
```