### PR TITLE
Update native install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Once you can build SpiderMonkey, you simply need to run `cargo build` as usual t
 You can install WinterJS natively with:
 
 ```
-cargo install --git https://github.com/wasmerio/winterjs
+cargo install --git https://github.com/wasmerio/winterjs winterjs
 ```
 
 Once you have WinterJS installed, you can simply do:


### PR DESCRIPTION
With the current instructions you will get:

```
error: multiple packages with binaries found: test-suite, winterjs. When installing a git repository, cargo will always search the entire repo for any Cargo.toml. Please specify a package, e.g. `cargo install --git https://github.com/wasmerio/winterjs test-suite`.
```

Must specify the binary to install.