### PR TITLE
Refactor: fix spelling inconsistencies that is test pass message

### DIFF
--- a/test-suite/js-test-app/src/test-files/10-atob-btoa.js
+++ b/test-suite/js-test-app/src/test-files/10-atob-btoa.js
@@ -44,7 +44,7 @@ async function handleRequest(request) {
       assert(true, "atob threw error as expected with invalid base64 input");
     }
     // Create a response with the Blob's text
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {

--- a/test-suite/js-test-app/src/test-files/11-fetch.js
+++ b/test-suite/js-test-app/src/test-files/11-fetch.js
@@ -235,7 +235,7 @@ async function handleRequest(request) {
     }
 
     // Create a response with the Blob's text
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {

--- a/test-suite/js-test-app/src/test-files/11.1-fetch-body.js
+++ b/test-suite/js-test-app/src/test-files/11.1-fetch-body.js
@@ -76,7 +76,7 @@ async function handleRequest(request) {
       assert_equals(await c.text(), "e, f, g\r\nh, i, j");
     }, "multipart/form-data body");
 
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {

--- a/test-suite/js-test-app/src/test-files/12-streams.js
+++ b/test-suite/js-test-app/src/test-files/12-streams.js
@@ -169,7 +169,7 @@ async function handleRequest(request) {
     }
 
     // Create a response with the Blob's text
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {

--- a/test-suite/js-test-app/src/test-files/12.1-transform-stream.js
+++ b/test-suite/js-test-app/src/test-files/12.1-transform-stream.js
@@ -2455,7 +2455,7 @@ async function handleRequest(request) {
       ]);
     }, "controller.terminate() inside flush() should not prevent writer.close() from succeeding");
 
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {

--- a/test-suite/js-test-app/src/test-files/12.2-text-encoder-stream.js
+++ b/test-suite/js-test-app/src/test-files/12.2-text-encoder-stream.js
@@ -73,7 +73,7 @@ async function handleRequest(request) {
         'object', 'writable property must pass brand check');
     }, 'TextEncoderStream readable and writable properties must pass brand checks');
 
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {

--- a/test-suite/js-test-app/src/test-files/12.3-text-decoder-stream.js
+++ b/test-suite/js-test-app/src/test-files/12.3-text-decoder-stream.js
@@ -294,7 +294,7 @@ async function handleRequest(request) {
         'object', 'writable property must pass brand check');
     }, 'TextDecoderStream readable and writable properties must pass brand checks');
 
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {

--- a/test-suite/js-test-app/src/test-files/13-performance.js
+++ b/test-suite/js-test-app/src/test-files/13-performance.js
@@ -31,7 +31,7 @@ async function handleRequest(request) {
             throw new Error(`More intervals elapsed after clearInterval was called, total before clearing ${totalIntervals}, after ${intervalsElapsed}`);
         }
 
-        return new Response('All Tests Passed!');
+        return new Response('All tests passed!');
     }
     catch (e) {
         return new Response(e.toString(), { status: 500 });

--- a/test-suite/js-test-app/src/test-files/14-form-data.js
+++ b/test-suite/js-test-app/src/test-files/14-form-data.js
@@ -299,7 +299,7 @@ async function handleRequest(request) {
       return formData;
     }
 
-    return new Response('All Tests Passed!');
+    return new Response('All tests passed!');
   }
   catch (e) {
     return new Response(e.toString(), { status: 500 });

--- a/test-suite/js-test-app/src/test-files/15-timers.js
+++ b/test-suite/js-test-app/src/test-files/15-timers.js
@@ -92,7 +92,7 @@ async function handleRequest(request) {
       timeout_trampoline(t, 100, "Expected setInterval callback to be called two times");
     }, "Calling setInterval with undefined interval should be the same as if called with 0 interval");
 
-    return new Response('All Tests Passed!');
+    return new Response('All tests passed!');
   }
   catch (e) {
     return new Response(e.toString(), { status: 500 });

--- a/test-suite/js-test-app/src/test-files/16-crypto.js
+++ b/test-suite/js-test-app/src/test-files/16-crypto.js
@@ -103,7 +103,7 @@ async function handleRequest(request) {
             }, "Null arrays: " + array);
         }
 
-        return new Response('All Tests Passed!');
+        return new Response('All tests passed!');
     }
     catch (e) {
         return new Response(e.toString(), { status: 500 });

--- a/test-suite/js-test-app/src/test-files/16.1-crypto-hmac.js
+++ b/test-suite/js-test-app/src/test-files/16.1-crypto-hmac.js
@@ -384,7 +384,7 @@ async function handleRequest(request) {
       return true;
     }
 
-    return new Response('All Tests Passed!');
+    return new Response('All tests passed!');
   }
   catch (e) {
     return new Response(e.toString(), { status: 500 });

--- a/test-suite/js-test-app/src/test-files/16.2-crypto-sha.js
+++ b/test-suite/js-test-app/src/test-files/16.2-crypto-sha.js
@@ -146,7 +146,7 @@ async function handleRequest(request) {
       }
     }
 
-    return new Response('All Tests Passed!');
+    return new Response('All tests passed!');
   }
   catch (e) {
     return new Response(e.toString(), { status: 500 });

--- a/test-suite/js-test-app/src/test-files/17-cache.js
+++ b/test-suite/js-test-app/src/test-files/17-cache.js
@@ -2484,7 +2484,7 @@ async function handleRequest(request) {
     //     });
     // }, 'CacheStorage names are DOMStrings not USVStrings');
 
-    return new Response('All Tests Passed!');
+    return new Response('All tests passed!');
   }
   catch (e) {
     return new Response(e.toString(), { status: 500 });

--- a/test-suite/winterjs-tests.toml
+++ b/test-suite/winterjs-tests.toml
@@ -97,83 +97,83 @@ expected_response_status = 200
 [[test_case]]
 test_name = "10-atob-btoa"
 test_route = "10-atob-btoa"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "11-fetch"
 test_route = "11-fetch"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "11.1-fetch-body"
 test_route = "11.1-fetch-body"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "12-streams"
 test_route = "12-streams"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "12.1-transform-stream"
 test_route = "12.1-transform-stream"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "12.2-text-encoder-stream"
 test_route = "12.2-text-encoder-stream"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "12.3-text-decoder-stream"
 test_route = "12.3-text-decoder-stream"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "13-performance"
 test_route = "13-performance"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "14-form-data"
 test_route = "14-form-data"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "15-timers"
 test_route = "15-timers"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "16-crypto"
 test_route = "16-crypto"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "16.1-crypto-hmac"
 test_route = "16.1-crypto-hmac"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "16.2-crypto-sha"
 test_route = "16.2-crypto-sha"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200
 
 [[test_case]]
 test_name = "17-cache"
 test_route = "17-cache"
-expected_output = "All Tests Passed!"
+expected_output = "All tests passed!"
 expected_response_status = 200

--- a/tests/wrangler.js
+++ b/tests/wrangler.js
@@ -46,7 +46,7 @@ async function handleRequest(request) {
       assert(true, "atob threw error as expected with invalid base64 input");
     }
     // Create a response with the Blob's text
-    return new Response("All Tests Passed!", {
+    return new Response("All tests passed!", {
       headers: { "content-type": "text/plain" },
     });
   } catch (error) {


### PR DESCRIPTION
## Overview

`All Tests Passed!` and `All tests passed!` were mixed up.
They are used as an expected result of the test.
It was confusing when adding tests, so they were aligned to 'All tests passed!

## Test

![スクリーンショット 2024-04-25 15 56 09](https://github.com/MasatoDev/winterjs/assets/46220963/49068f46-873e-4ae8-af2d-24d4dfffbc1b)
